### PR TITLE
Add a new repository for the mat website

### DIFF
--- a/otterdog/eclipse-mat.jsonnet
+++ b/otterdog/eclipse-mat.jsonnet
@@ -43,5 +43,15 @@ orgs.newOrg('eclipse-mat') {
         enabled: false,
       },
     },
+    orgs.newRepo('website') {
+      allow_merge_commit: true,
+      allow_update_branch: false,
+      default_branch: "main",
+      delete_branch_on_merge: false,
+      web_commit_signoff_required: false,
+      workflows+: {
+        enabled: false,
+      },
+    },
   ],
 }


### PR DESCRIPTION
The MAT site still uses php and we'd change this.
We'll build the website with Hugo and for this I'd like to have a separate repository.
As we are a small team, we do rarely changes to the website, and we never have changes in parallel, I'd like to stick to (what I consider a simpler approach) of having both the src files for Hugo as well as the generated site in the same repo.
Once we've fully migrated, I'll need to rename the current website repo and if possible make it read only.

This is my first attempt to use otterdog - apologies if I got things wrong and please give me some guidance in this case :)