### PR TITLE
Add a new repository for the mat website public content

### DIFF
--- a/otterdog/eclipse-mat.jsonnet
+++ b/otterdog/eclipse-mat.jsonnet
@@ -53,5 +53,15 @@ orgs.newOrg('eclipse-mat') {
         enabled: false,
       },
     },
+    orgs.newRepo('website-public') {
+      allow_merge_commit: true,
+      allow_update_branch: false,
+      default_branch: "main",
+      delete_branch_on_merge: false,
+      web_commit_signoff_required: false,
+      workflows+: {
+        enabled: false,
+      },
+    },
   ],
 }


### PR DESCRIPTION
Following the discussion in https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/5234 - 
we will need a second repository to hold the generated the static content of the mat website.