### PR TITLE
Archive 'mat-website' repository

### DIFF
--- a/otterdog/eclipse-mat.jsonnet
+++ b/otterdog/eclipse-mat.jsonnet
@@ -34,6 +34,7 @@ orgs.newOrg('eclipse-mat') {
       web_commit_signoff_required: false,
     },
     orgs.newRepo('mat-website') {
+      archived: true
       allow_merge_commit: true,
       allow_update_branch: false,
       default_branch: "master",

--- a/otterdog/eclipse-mat.jsonnet
+++ b/otterdog/eclipse-mat.jsonnet
@@ -34,7 +34,7 @@ orgs.newOrg('eclipse-mat') {
       web_commit_signoff_required: false,
     },
     orgs.newRepo('mat-website') {
-      archived: true
+      archived: true,
       allow_merge_commit: true,
       allow_update_branch: false,
       default_branch: "master",

--- a/otterdog/eclipse-mat.jsonnet
+++ b/otterdog/eclipse-mat.jsonnet
@@ -55,8 +55,8 @@ orgs.newOrg('eclipse-mat') {
       },
     },
     orgs.newRepo('website-public') {
-      description = "This repository hosts the content of the Eclipse Memory Analyzer website. The content is build with hugo from https://github.com/eclipse-mat/website",
-      homepage    = "",
+      description: "This repository hosts the content of the Eclipse Memory Analyzer website. The content is build with hugo from https://github.com/eclipse-mat/website",
+      homepage: "",
       allow_merge_commit: true,
       allow_update_branch: false,
       default_branch: "main",

--- a/otterdog/eclipse-mat.jsonnet
+++ b/otterdog/eclipse-mat.jsonnet
@@ -55,6 +55,8 @@ orgs.newOrg('eclipse-mat') {
       },
     },
     orgs.newRepo('website-public') {
+      description = "This repository hosts the content of the Eclipse Memory Analyzer website. The content is build with hugo from https://github.com/eclipse-mat/website",
+      homepage    = "",
       allow_merge_commit: true,
       allow_update_branch: false,
       default_branch: "main",


### PR DESCRIPTION
Because of the php support deprecation, the MAT website moved to a new home:
- https://github.com/eclipse-mat/website contains the source
- https://github.com/eclipse-mat/website-public contains the generated static content

With these changes the 'mat-website' repository became obsolete, therefore this change is intended to archive it